### PR TITLE
Add initial Russian language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,18 @@ Simplified:
 
 ![28](samples/28.jpg "1")
 
-## Create images with Japanese text 
+## Create images with Japanese text
 
 It is simple! Just do `trdg -l ja -c 1000 -w 5`!
 
 Output 
 
 ![29](samples/29.jpg "2")
+
+
+## Create images with Russian text
+
+It is simple! Just do `trdg -l ru -c 1000 -w 5`!
 
 
 ## Add new fonts
@@ -183,6 +188,7 @@ The script picks a font at random from the *fonts* directory.
 | fonts/cn | Chinese |
 | fonts/ko | Korean |
 | fonts/ja | Japanese |
+| fonts/ru | Russian |
 | fonts/th | Thai |
 
 Simply add/remove fonts until you get the desired output.

--- a/trdg/fonts/ru/.gitkeep
+++ b/trdg/fonts/ru/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder for Russian fonts

--- a/trdg/run.py
+++ b/trdg/run.py
@@ -53,7 +53,7 @@ def parse_arguments():
         "--language",
         type=str,
         nargs="?",
-        help="The language to use, should be fr (French), en (English), es (Spanish), de (German), ar (Arabic), cn (Chinese), ja (Japanese) or hi (Hindi)",
+        help="The language to use, should be fr (French), en (English), es (Spanish), de (German), ar (Arabic), cn (Chinese), ja (Japanese), hi (Hindi) or ru (Russian)",
         default="en",
     )
     parser.add_argument(

--- a/trdg/string_generator.py
+++ b/trdg/string_generator.py
@@ -112,6 +112,10 @@ def create_strings_randomly(
                 [chr(i) for i in range(19968, 40908)]
             )  # unicode range for common and uncommon kanji
             # https://stackoverflow.com/questions/19899554/unicode-range-for-japanese
+        elif lang == "ru":
+            # Cyrillic characters for Russian
+            pool += "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
+            pool += "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
         else:
             pool += string.ascii_letters
     if num:


### PR DESCRIPTION
## Summary
- extend random string generation to include Cyrillic characters for Russian
- add Russian to CLI language help and documentation
- include placeholder directory for Russian fonts

## Testing
- `python -m unittest tests.Generators.test_generator_from_dict tests.DataGenerator.test_create_strings_from_dict`
- `python tests.py` *(fails: FileNotFoundError: No such file or directory 'fonts/void/' and network errors fetching Wikipedia)*

------
https://chatgpt.com/codex/tasks/task_e_68c6816c4f24832486a45e6b6ef6918b